### PR TITLE
Eval in content script

### DIFF
--- a/js/cs/script.js
+++ b/js/cs/script.js
@@ -1,1 +1,1 @@
-console.log("CONTENT SCRIPT LAUNCHED");
+eval("console.log('CONTENT SCRIPT LAUNCHED')");

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,12 @@
 {
    "author": "Manvel",
-   "manifest_version": 2,
+   "manifest_version": 3,
    "default_locale": "en_US",
    "name": "__MSG_chrome_extension_name__",
    "description": "__MSG_chrome_extension_description__",
    "background": {
-      "scripts": ["js/background.js"],
-      "persistent": false 
-   },
+      "service_worker": "js/background.js"
+    },
    "browser_action": {
       "default_icon": "images/icon/128x128.png",
       "default_popup": "popup.html"
@@ -33,6 +32,5 @@
      "open_in_tab": true,
      "browser_style": false
    },
-   "content_security_policy": "script-src 'self' 'unsafe-eval' object-src 'self'",
    "version": "0.1"
 }


### PR DESCRIPTION
Throws current error:

```
Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".
```