### PR TITLE
Declarative net requests

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,1 +1,12 @@
-console.log("BACKGROUND PAGE LAUNCHED");
+const onSendHeaders = chrome.webRequest.onSendHeaders;
+const onHeadersReceived = chrome.webRequest.onHeadersReceived;
+
+
+const urls = {urls: ["<all_urls>"]};
+onSendHeaders.addListener((request) => {
+  console.log("onSendHeaders", request);
+}, urls, ["requestHeaders"]);
+
+onHeadersReceived.addListener((response) => {
+  console.log("onHeadersReceived", response);
+}, urls, ["responseHeaders"]);

--- a/manifest.json
+++ b/manifest.json
@@ -16,9 +16,8 @@
       "48": "images/icon/48x48.png",
       "16": "images/icon/16x16.png"
    },
-   "permissions": [
-      "*://*/*", "<all_urls>"
-   ],
+   "permissions": [],
+   "host_permissions": ["*://*/*", "<all_urls>"],
    "content_scripts": [
       {
          "js": ["js/cs/script.js"],

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
    "background": {
       "service_worker": "js/background.js"
     },
-   "browser_action": {
+   "action": {
       "default_icon": "images/icon/128x128.png",
       "default_popup": "popup.html"
    },

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
       "48": "images/icon/48x48.png",
       "16": "images/icon/16x16.png"
    },
-   "permissions": [],
+   "permissions": ["webRequest"],
    "host_permissions": ["*://*/*", "<all_urls>"],
    "content_scripts": [
       {

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,12 @@
 {
    "author": "Manvel",
-   "manifest_version": 2,
+   "manifest_version": 3,
    "default_locale": "en_US",
    "name": "__MSG_chrome_extension_name__",
    "description": "__MSG_chrome_extension_description__",
    "background": {
-      "scripts": ["js/background.js"],
-      "persistent": false 
-   },
+      "service_worker": "js/background.js"
+    },
    "browser_action": {
       "default_icon": "images/icon/128x128.png",
       "default_popup": "popup.html"
@@ -33,6 +32,5 @@
      "open_in_tab": true,
      "browser_style": false
    },
-   "content_security_policy": "script-src 'self' 'unsafe-eval' object-src 'self'",
    "version": "0.1"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,14 @@
       "48": "images/icon/48x48.png",
       "16": "images/icon/16x16.png"
    },
-   "permissions": ["webRequest"],
+   "declarative_net_request" : {
+      "rule_resources" : [{
+        "id": "block-ua",
+        "enabled": true,
+        "path": "./rules/block-us.json"
+      }]
+    },
+   "permissions": ["webRequest", "declarativeNetRequest"],
    "host_permissions": ["*://*/*", "<all_urls>"],
    "content_scripts": [
       {

--- a/rules/block-us.json
+++ b/rules/block-us.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": { 
+      "type": "modifyHeaders",
+      "requestHeaders": [{
+        "header": "user-agent",
+        "operation": "remove"
+      }]
+    },
+    "condition": {"excludedResourceTypes": ["main_frame"]}
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": { 
+      "type": "modifyHeaders",
+      "requestHeaders": [{
+        "header": "user-agent",
+        "operation": "remove"
+      }]
+    },
+    "condition": {"resourceTypes": ["main_frame"]}
+  }
+]


### PR DESCRIPTION
# webRequest works
`webRequest` api does work with the Manifest V3, the one that doesn't is `webRequestBlocking`.

Which mean that it's still possible to monitor web requests using `webRequest`, but not possible to block or modify.
